### PR TITLE
 Fix NGPB atom potential parsing

### DIFF
--- a/bin/pbs_interfaces.py
+++ b/bin/pbs_interfaces.py
@@ -637,8 +637,31 @@ class PBS_NGPB:
             logger.critical("Could not open NGPB output file phi_on_atoms.txt.")
             sys.exit(1)
 
-        for counter in range(len(xyzrcp)):
-            phi = float(lines[counter][:].split()[3])
+        expected_lines = len(xyzrcp)
+        if len(lines) < expected_lines:
+            logger.critical(
+                "NGPB output phi_on_atoms.txt has fewer lines than expected: "
+                "%d lines for %d atoms." % (len(lines), expected_lines)
+            )
+            sys.exit(1)
+
+        for counter in range(expected_lines):
+            parts = lines[counter].split()
+            if not parts:
+                logger.critical(
+                    "NGPB output phi_on_atoms.txt has an empty line at line %d."
+                    % (counter + 1)
+                )
+                sys.exit(1)
+
+            try:
+                phi = float(parts[-1])
+            except ValueError:
+                logger.critical(
+                    "Could not parse NGPB atom potential from phi_on_atoms.txt "
+                    "line %d: %r" % (counter + 1, lines[counter].rstrip("\n"))
+                )
+                sys.exit(1)
             xyzrcp[counter].p = phi
 
         return


### PR DESCRIPTION
This change makes PBS_NGPB.collect_phi() parse atom potentials from the last column of phi_on_atoms.txt instead of assuming the fourth whitespace-separated field is always present.

NGPB writes atom potentials as x y z phi, but when coordinates reach values such as -100.xxx, adjacent fixed-width coordinate fields can be emitted without whitespace, for example:

21.776  -6.713-100.288  0.0000

The previous parser used split()[3], which raises IndexError on these lines because -6.713-100.288 becomes one token. The potential value remains the last token, so parsing split()[-1] handles both normal and glued-coordinate lines.

This also adds clearer error handling for truncated output, empty lines, and unparseable potential values, so future NGPB output issues report actionable diagnostics instead of a generic list index out of range.